### PR TITLE
Adding description to signaling options

### DIFF
--- a/I-D-L2NM/draft-ietf-opsawg-l2nm.xml
+++ b/I-D-L2NM/draft-ietf-opsawg-l2nm.xml
@@ -905,24 +905,21 @@
 
           <section anchor="signaling_options" title="Signaling Options">
             <t>This sub-tree defines the L2VPN service type, according to the
-            several signalling options to exchange membership information
+            several signaling options to exchange membership information
             between PEs of an L2VPN. The following signaling options are
             supported:</t>
 
             <t><list style="hanging">
-                <t hangText="'l2vpn-bgp':">Refers to the BGP control plane as
-                described in <xref target="RFC4761"></xref> and <xref
-                target="RFC6624"></xref>.</t>
+              <t hangText="'l2vpn-bgp':"> The service is a Multipoint VPLSs that use a BGP control plane as described in <xref target="RFC4761"></xref> and <xref
+                target="RFC6624"></xref>. For this L2VPN service, the model allows configuring the Route Distinguisher, the Route Targets, the PWE encapsulation type and the MTU configurations to allow MTU mismatch.</t>
+              
+                <t hangText="'evpn-bgp':">The service is a Multipoint VPLSs that use also a BGP control plane but also includes the additional features and related parameters <xref target="RFC7432"></xref> and <xref
+                target="RFC7209"></xref>. The model allows the configuration of the EVPN service interface type, the local and remote VPWS Service Instance (VSI) <xref
+                target="RFC8214"></xref>, the EVPN policies for handling MAC addresses and the Ethernet Segment Identifier (ESI) information.</t>
 
-                <t hangText="'evpn-bgp':">Refers to the BGP control plane as
-                described in <xref target="RFC7432"></xref> and <xref
-                target="RFC7209"></xref>.</t>
+                <t hangText="'t-ldp-pwe':">A Multipoint VPLSs that use a mesh of LDP-signaled Pseudowires <xref target="RFC6074"></xref>. The model allows configuring the T-LDP PWE type, MTU mismatch and the list of AC and PW bindings.</t>
 
-                <t hangText="'t-ldp-pwe':">Refers to LDP-signaled pseudowires
-                <xref target="RFC6074"></xref>.</t>
-
-                <t hangText="'l2tp-pwe':">Refers to L2TP-signaled pseudowires
-                <xref target="RFC6074"></xref>.</t>
+                <t hangText="'l2tp-pwe':">The L2 VPN uses L2TP-signaled Pseudowires as described in <xref target="RFC6074"></xref>. The model allows configuring TBC.</t>
               </list></t>
 
             <texttable anchor="service-sig"
@@ -1800,7 +1797,7 @@ module ietf-l2vpn-ntw {
   }*/
   /*feature signaling-options {
     description
-      "Indicates the support of signalling option.";
+      "Indicates the support of signaling option.";
   }*/
   /*feature always-on {
     description

--- a/yang/ietf-l2vpn-ntw.yang
+++ b/yang/ietf-l2vpn-ntw.yang
@@ -1390,7 +1390,7 @@ module ietf-l2vpn-ntw {
                     leaf vc-id {
                       type vpn-common:vpn-id;
                       description
-                        "VC lable used to identify PW.";
+                        "VC label used to identify PW.";
                     }
                     leaf pw-type {
                       type identityref {
@@ -1460,7 +1460,7 @@ module ietf-l2vpn-ntw {
                     leaf vc-id {
                       type string;
                       description
-                        "VC lable used to identify PW.";
+                        "VC label used to identify PW.";
                     }
                     leaf pw-priority {
                       type uint32;


### PR DESCRIPTION
Adding a description to signaling options to improve readability.

I have pending to update L2TP after the other issue is solved
https://github.com/IETF-OPSAWG-WG/lxnm/issues/311