### PR TITLE
Qin Wu Comments

### DIFF
--- a/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
+++ b/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
@@ -2797,7 +2797,7 @@ module ietf-l3vpn-ntw {
   import ietf-vpn-common {
     prefix vpn-common;
     reference
-      "RFC XXX: A Layer 2/3 VPN Common YANG Model";
+      "RFC XXXX: A Layer 2/3 VPN Common YANG Model";
   }
   import ietf-inet-types {
     prefix inet;

--- a/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
+++ b/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
@@ -641,7 +641,7 @@
           are part of a topology managed by the service provider network. Such
           The topology can be represented using the network topology YANG module defined in
           <xref target="RFC8345"></xref> or its extension such as a User-Network Interface (UNI)
-          topology module <xref target="I-D.ogondio-opsawg-uni-topology"></xref>.</t>
+          topology module (e.g., <xref target="I-D.ogondio-opsawg-uni-topology"></xref>).</t>
 
           <t hangText="Device Modules:">L3NM is not a device model. <vspace
           blankLines="1" />Once a global VPN service is captured by means of

--- a/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
+++ b/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
@@ -289,7 +289,7 @@
       orchestrator in the L3NM (e.g., customer) or be used to feed some L3NM
       attributes (e.g., actual forwarding policies). Also, some information
       captured in the L3SM may be maintained locally within the orchestrator;
-      which is in charge of maintaining the correspondence between a customer
+      which is in charge of maintaining the correlation between a customer
       view and its network instantiation. Likewise, some information captured
       and exposed using the L3NM can feed the service layer (e.g.,
       capabilities) to drive VPN service order handling, and thus the
@@ -639,8 +639,9 @@
 
           <t hangText="Network Topology Modules:">An L3VPN involves nodes that
           are part of a topology managed by the service provider network. Such
-          topology can be represented using the network topology module in
-          <xref target="RFC8345"></xref>.</t>
+          topology can be represented usign the network topology module in
+          <xref target="RFC8345"></xref> or its extension module such as UNI 
+          topology module <xref target="I-D.ogondio-opsawg-uni-topology"></xref>.</t>
 
           <t hangText="Device Modules:">L3NM is not a device model. <vspace
           blankLines="1" />Once a global VPN service is captured by means of
@@ -686,7 +687,7 @@
         still be required.</t>
 
         <t>A common function that is supported by VPNs is the addition or
-        removal of customer sites. Workflows can use the L3NM in these
+        removal of VPN nodes. Workflows can use the L3NM in these
         scenarios to add or prune nodes from the network data model as
         required.</t>
       </section>
@@ -704,7 +705,7 @@
         allocation can be performed by that management system. In cases where
         the service spans across multiple management systems, the task of
         allocating RTs has to be aligned across the domains, therefore, the
-        service model must provide a way to specify RTs. In addition, route
+        network model must provide a way to specify RTs. In addition, route
         distinguishers (RDs) must also be synchronized to avoid collisions in
         RD allocation between separate management systems. An incorrect
         allocation might lead to the same RD and IP prefixes being exported by
@@ -1085,7 +1086,7 @@
             System Number (ASN) that is configured for the VPN node.</t>
 
             <t hangText="'rd':">As defined in <xref
-            target="I-D.ietf-opsawg-vpn-common"></xref>, these RD assignment
+            target="I-D.ietf-opsawg-vpn-common"></xref>, the following RD assignment
             modes are supported: direct assignment, automatic assignment from
             a given pool, automatic assignment, and no assignment. For
             illustration purposes, the following modes can be used in the
@@ -1357,7 +1358,7 @@
             administrative status of a VPN network access.</t>
 
             <t hangText="'connection':">Represents and groups the set of Layer
-            2 connectivity from where the traffic of the L3VPN in a particular
+            2 connectivity from which the traffic of the L3VPN in a particular
             VPN Network access is coming. See <xref
             target="connection"></xref>.</t>
 
@@ -1738,7 +1739,7 @@
               prefix.</t>
 
               <t hangText="'status':">Used to convey the status of a static
-              route entry. This data node is used to control the
+              route entry. This data node can also be used to control the
               (de)activation of individual static route entries.</t>
             </list></t>
 
@@ -1854,7 +1855,7 @@
                   Extended Community.</t>
 
                   <t hangText="'ipv6-site-of-origin':">Carries an IPv6 Address
-                  Specific BGP Extended that is used to indicate the Site of
+                  Specific BGP Extended Community that is used to indicate the Site of
                   Origin for VRF information <xref target="RFC5701"></xref>.
                   It is used to prevent routing loops.</t>
 
@@ -2451,7 +2452,7 @@
                   <t hangText="Layer 4:">As discussed in <xref
                   target="I-D.ietf-opsawg-vpn-common"></xref>, any layer 4
                   protocol can be indicated in the 'protocol' data node under
-                  'l3' (<xref target="services-l3"></xref>), but only TCP and
+                  'l3' (<xref target="services-l4"></xref>), but only TCP and
                   UDP specific match criteria are elaborated in this version
                   as these protocols are widely used in the context of VPN
                   services. Augmentations can be considered in the future to
@@ -2796,7 +2797,7 @@ module ietf-l3vpn-ntw {
   import ietf-vpn-common {
     prefix vpn-common;
     reference
-      "RFC UUUU: A Layer 2/3 VPN Common YANG Model";
+      "RFC XXX: A Layer 2/3 VPN Common YANG Model";
   }
   import ietf-inet-types {
     prefix inet;

--- a/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
+++ b/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
@@ -2797,7 +2797,7 @@ module ietf-l3vpn-ntw {
   import ietf-vpn-common {
     prefix vpn-common;
     reference
-      "RFC XXXX: A Layer 2/3 VPN Common YANG Model";
+      "RFC UUUU: A Layer 2/3 VPN Common YANG Model";
   }
   import ietf-inet-types {
     prefix inet;

--- a/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
+++ b/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
@@ -640,7 +640,7 @@
           <t hangText="Network Topology Modules:">An L3VPN involves nodes that
           are part of a topology managed by the service provider network. Such
           The topology can be represented using the network topology YANG module defined in
-          <xref target="RFC8345"></xref> or its extension module such as UNI 
+          <xref target="RFC8345"></xref> or its extension such as a User-Network Interface (UNI)
           topology module <xref target="I-D.ogondio-opsawg-uni-topology"></xref>.</t>
 
           <t hangText="Device Modules:">L3NM is not a device model. <vspace

--- a/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
+++ b/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
@@ -639,7 +639,7 @@
 
           <t hangText="Network Topology Modules:">An L3VPN involves nodes that
           are part of a topology managed by the service provider network. Such
-          topology can be represented usign the network topology module in
+          The topology can be represented using the network topology YANG module defined in
           <xref target="RFC8345"></xref> or its extension module such as UNI 
           topology module <xref target="I-D.ogondio-opsawg-uni-topology"></xref>.</t>
 

--- a/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
+++ b/I-D-L3NM/draft-ietf-opsawg-l3sm-l3nm.xml
@@ -2452,7 +2452,7 @@
                   <t hangText="Layer 4:">As discussed in <xref
                   target="I-D.ietf-opsawg-vpn-common"></xref>, any layer 4
                   protocol can be indicated in the 'protocol' data node under
-                  'l3' (<xref target="services-l4"></xref>), but only TCP and
+                  'l3' (<xref target="services-l3"></xref>), but only TCP and
                   UDP specific match criteria are elaborated in this version
                   as these protocols are widely used in the context of VPN
                   services. Augmentations can be considered in the future to


### PR DESCRIPTION
Reviewer: Qin Wu
Review result: Has Nits

I have reviewed this document as part of the Operational directorate's ongoing
effort to review all IETF documents being processed by the IESG.  These
comments were written with the intent of improving the operational aspects of
the IETF drafts. Comments that are not addressed in last call may be included
in AD reviews during the IESG review.  Document editors and WG chairs should
treat these comments just like any other last call comments.

Summary:
This document defines L3VPN network model for provisioning L3VPN service within
service provider network. It provides network centric view of L3VPN service. I
think this document is well written and ready for publication. However I have a
few editorial comments I want like authors to consider.

Major issue: None
Nits:
1. Section 1, Paragraph 6
Is correspondence referred to corresponding relation or correlation? If they
are equivalent, I am okay with the current wording.

2. Section 5, Network topology module bullet
s/using the network topology module in [RFC8345]
/using the network topology module in [RFC8345]
Or its extension module such as UNI topology module
[I-D.ogondio-opsawg-uni-topology]

3.Section 6.1 Paragraph 1
The last sentence describes Causal relationship between template and batch
process and abstracting the parameter into upper SDN layer, it is not very
clear to me that which one is cause? Which one is effect? Maybe I am wrong.

4.Section 6.1 Paragraph 2
Customer sites are not modelled in the L3NM any more How about
s/ the addition or removal of customer sites / the addition or removal of VPN
nodes

5.Section 6.1 Paragraph 2
Is RT/RD synchronization mechanism between Pes in the scope of document? If
none, please make this clear.

6.Section 6.2, Paragraph 2
s/service model/network model

7.Section 6.3 Paragraph 2
Is MPLS P2MP the only transport for multicast traffic in this case or just an
example transport?

8.Section 7.4 'rd'definition
s/ these RD/the following RD

9. Section 7.6 'connection' definition
s/from where/from which

10. Section 7.6.3 said:
"The L3NM supports the configuration of one or more IPv4/IPv6 static
   routes.  Since the same structure is used for both IPv4 and IPv6, it
   was considered to have one single container to group both static
   entries independently of their address family, but that design was
   abandoned to ease the mapping with the structure in [RFC8299].
"
I think you emphasize that the L2NM and L3NM to follow the similar structure to
ease the mapping.

11.Section 7.6.3, 'status' definition
s/ is used to control the (de)activation/can also be used to control the
(de)activation

12. Section 7.6.3 'ipv6-site-of-origin' definition
s/IPv6 Address Specific BGP Extended/IPv6 Address Specific BGP Extended
Community

13. Section 7.6.3 'authentition' definition under BGP
I think we support different authentication modes such as TCP AO support, IPSEC
support, TLS support. I am not sure that TCP MD5 should be supported as an
option since it has break many protocols.

14. Section 7.6.6 'Layer 4' definition
s/data node under ‘l3’ (Figure 25)/data node under ‘l4’ (Figure 26)
I didn’t check other figure number consistency.

15. Section 8
s/RFC UUU/RFC XXX
