### PR TITLE
remove list from the lag-interface-335

### DIFF
--- a/yang/ietf-l2vpn-ntw.yang
+++ b/yang/ietf-l2vpn-ntw.yang
@@ -1833,10 +1833,6 @@ module ietf-l2vpn-ntw {
                     description
                       "Container of LAG interface attributes
                        configuration";
-                    list lag-interface {
-                      key "lag-interface-number";
-                      description
-                        "List of LAG interfaces";
                       leaf lag-interface-number {
                         type uint32;
                         description
@@ -1939,7 +1935,6 @@ module ietf-l2vpn-ntw {
                             "LLDP";
                         }
                       }
-                    }
                     container split-horizon {
                       description
                         "Configuration with split horizon enabled";

--- a/yang/ietf-l2vpn-ntw.yang
+++ b/yang/ietf-l2vpn-ntw.yang
@@ -1832,11 +1832,11 @@ module ietf-l2vpn-ntw {
                     if-feature "vpn-common:lag-interface";
                     description
                       "Container of LAG interface attributes
-                       configuration";
-                      leaf lag-interface-number {
-                        type uint32;
+                       configuration.";
+                      leaf lag-interface-id {
+                        type string;
                         description
-                          "LAG interface number";
+                          "LAG interface identifier.";
                       }
                       container lacp {
                         description


### PR DESCRIPTION
The proposed solution:
```
+--rw lag-interface {vpn-common:lag-interface}?
|     +--rw lag-interface-number?   uint32
|     +--rw lacp
|     |  +--rw lacp-state?         boolean
|     |  +--rw lacp-mode?          boolean
|     |  +--rw lacp-speed?         boolean
|     |  +--rw mini-link?          uint32
|     |  +--rw system-id?          yang:mac-address
|     |  +--rw admin-key?          uint16
|     |  +--rw system-priority?    uint16
|     |  +--rw member-link-list
|     |  |  +--rw member-link* [name]
|     |  |     +--rw name                string
|     |  |     +--rw port-speed?         uint32
|     |  |     +--rw mode?               identityref
|     |  |     +--rw link-mtu?           uint32
|     |  |     +--rw oam-802.3ah-link {oam-3ah}?
|     |  |        +--rw enable?   boolean
|     |  +--rw flow-control?       string
|     |  +--rw lldp?               boolean
|     +--rw split-horizon
|        +--rw group-name?   string
```